### PR TITLE
update base to 2.7.3-dev

### DIFF
--- a/packages/opencpu-fhpredict-api/Dockerfile
+++ b/packages/opencpu-fhpredict-api/Dockerfile
@@ -4,7 +4,7 @@
 # change opencpu Password
 ######## https://hub.docker.com/r/opencpu/base/dockerfile #
 # FROM opencpu/base:v2.1.3
-FROM technologiestiftung/flusshygiene-opencpu-base:v2.7.1-dev as base
+FROM technologiestiftung/flusshygiene-opencpu-base:v2.7.3-dev as base
 LABEL maintainer="moron-zirfas@technologiestiftung-berlin.de"
 LABEL "de.technologiestiftung-berlin"="Technologiestiftung Berlin"
 LABEL description="This runs our package kwb-r/fhpredict package on a opencpu api"


### PR DESCRIPTION
Testing if the build of fhpredict works with
- [technologiestiftung/flusshygiene-opencpu-base:v2.7.3-dev](https://hub.docker.com/layers/technologiestiftung/flusshygiene-opencpu-base/v2.7.3-dev/images/sha256-14137810725e9878fc4b0ed5bf0c9ac8cf9e43ac4c661b3f1c97dd469098eb6d?context=repo)
- based on opencpu/base:2.1.6
- with fhpredict v0.10.0

cc @hsonne 